### PR TITLE
Ensure domovoi errors when there is no handler

### DIFF
--- a/domovoi/app.py
+++ b/domovoi/app.py
@@ -101,6 +101,7 @@ class Domovoi(Chalice):
     def __call__(self, event, context):
         context.log("Domovoi dispatch of event {}".format(event))
         invoked_function_arn = ARN(context.invoked_function_arn)
+        handler = None
         if "task_name" in event:
             if event["task_name"] not in self.cloudwatch_events_rules:
                 raise DomovoiException("Received CloudWatch event for a task with no known handler")
@@ -132,7 +133,8 @@ class Domovoi(Chalice):
             task_name = lambda_alias[len("domovoi-stepfunctions-task-"):]
             context.stepfunctions_task_name = task_name
             handler = self.sfn_tasks[task_name]["func"]
-        else:
+
+        if handler is None:
             raise DomovoiException("No handler found for event {}".format(event))
         result = handler(event, context)
         context.log(result)


### PR DESCRIPTION
This issue has been observed when a bucket that has no `s3_subscribers` registered with domovoi has SNS messages enabled on `CreateObject`. Under these circumstances, `_find_sns_s3_event_sub` returns no handler, domovoi tries to call `None` with args `(event, context)` and the following exception is thrown.

```
'NoneType' object is not callable: TypeError Traceback (most recent call last): File "/var/task/domovoi/app.py", line 137, in __call__ result = handler(event, context) TypeError: 'NoneType' object is not callable
'NoneType' object is not callable: TypeError
Traceback (most recent call last):
File "/var/task/domovoi/app.py", line 137, in __call__
result = handler(event, context)
TypeError: 'NoneType' object is not callable
```

This PR makes sure an informative error is thrown.