### PR TITLE
Use Python logging library instead of Lambda context.log.

### DIFF
--- a/domovoi/app.py
+++ b/domovoi/app.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import json, gzip, base64
+import json, gzip, base64, logging
 
 from chalice.app import Chalice, LambdaFunction
+
+logger = logging.getLogger(__name__)
 
 class DomovoiException(Exception):
     pass
@@ -145,7 +147,7 @@ class Domovoi(Chalice):
         return s3_event, handler
 
     def __call__(self, event, context):
-        context.log("Domovoi dispatch of event {}".format(event))
+        logger.debug("Domovoi dispatch of event %r", event)
         self.lambda_context = context
         invoked_function_arn = ARN(context.invoked_function_arn)
         handler = None
@@ -191,5 +193,5 @@ class Domovoi(Chalice):
         if handler is None:
             raise DomovoiException("No handler found for event {}".format(event))
         result = handler(event, context)
-        context.log(result)
+        logger.debug("%r", result)
         return result


### PR DESCRIPTION
The Lambda context.log function being used by Domovoi is not longer documented and doesn't allow the library user to control whether the log messages are produced at runtime. Using the Python standard library logging module is arguably more _Pythonic_ and gives output control back to the user.
